### PR TITLE
Building independent tests individually in the same package fail

### DIFF
--- a/multi-test-suite.cabal
+++ b/multi-test-suite.cabal
@@ -45,6 +45,14 @@ test-suite multi-test-suite-test-2
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
 
+test-suite multi-test-suite-test-3
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      test-3
+  main-is:             Spec.hs
+  build-depends:       base
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
+  default-language:    Haskell2010
+
 source-repository head
   type:     git
   location: https://github.com/commercialhaskell/multi-test-suite

--- a/test-3/Spec.hs
+++ b/test-3/Spec.hs
@@ -1,0 +1,2 @@
+main :: IO ()
+main = return ()


### PR DESCRIPTION
``` sh
stack build --test multi-test-suite:test:multi-test-suite-test-2
...
multi-test-suite-0.1.0.0: test (suite: multi-test-suite-test-2)
Completed all 3 actions.
```

``` sh
stack build --test multi-test-suite:test:multi-test-suite-test-3
Test suite multi-test-suite-test-3 executable not found for multi-test-suite
Test suite failure for package multi-test-suite-0.1.0.0
    multi-test-suite-test-3:  executable not found
Logs printed to console
```

``` sh
stack --version
Version 0.1.9.0, Git revision b7773e05b10c6ac8ee18d7a08c109d537951f018 (dirty) (2629 commits) x86_64
```

possibly related to commercialhaskell/stack#1399
